### PR TITLE
chore: Remove package name from releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "bump-minor-pre-major": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
We want tags such as `v0.1.0`, and not `foreman-v0.1.0`.