### PR TITLE
feat: Show a message when the job list is empty

### DIFF
--- a/frontend/src/pages/Jobs.tsx
+++ b/frontend/src/pages/Jobs.tsx
@@ -3,23 +3,46 @@ import { useApiSubscription } from '../api/subscription.js'
 import { api } from '../api/api.js'
 import { Heading } from '../components/Heading.js'
 import { JobPanel } from '../components/JobPanel.js'
+import { ErrorMessage } from '../components/ErrorMessage.js'
 
 export const Jobs: FunctionComponent = () => {
-  const { loading, data: jobs } = useApiSubscription({ interval: 5_000 }, api.jobs)
+  const { loading, data: jobs, error } = useApiSubscription({ interval: 5_000 }, api.jobs)
 
   return (
     <div>
       <Heading>
         Job History
       </Heading>
-      {!loading
-        ? jobs?.map((job) => (
-          <JobPanel key={`${job.namespace}/${job.name}`} name={job.name} namespace={job.namespace} status={job.status} startTime={job.startTime} manual={job.manual} />
-        ))
-        : [...Array(8)].map((_, i) => (
-          <JobPanel key={i} name={undefined} namespace={undefined} status={undefined} startTime={undefined} manual={false} />
-          ))
-      }
+      {error != null && (
+        <ErrorMessage>
+          Error loading jobs: {error.message}
+        </ErrorMessage>
+      )}
+      {jobs != null && jobs.length === 0 && (
+        <p>
+          There are no previous jobs. Once a job is run, it will appear here automatically.
+        </p>
+      )}
+      {jobs?.map((job) => (
+        <JobPanel
+          key={`${job.namespace}/${job.name}`}
+          name={job.name}
+          namespace={job.namespace}
+          status={job.status}
+          startTime={job.startTime}
+          manual={job.manual}
+        />
+      ))}
+      {loading && [...Array(8)].map((_, i) => (
+        <JobPanel
+          key={i}
+          name={undefined}
+          namespace={undefined}
+          status={undefined}
+          startTime={undefined}
+          manual={false}
+        />
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
Fixes #11. The Jobs page would previously be completely empty (besides the heading) if there aren't any jobs. We now show a message there to inform the user that the emptiness is intentional, and that the page will refresh automatically once jobs arrive.

Error handling is also added to the page.