### PR TITLE
feat: Verify job ownership

### DIFF
--- a/backend/src/api/jobs.ts
+++ b/backend/src/api/jobs.ts
@@ -5,7 +5,7 @@ import { authenticateSession } from '../auth/common.js'
 import { V1Job } from '@kubernetes/client-node'
 import assert from 'node:assert'
 import { DEFAULT_NAMESPACE } from '../kubernetes/api.js'
-import { ForemanAnnotations } from '../annotations.js'
+import { ForemanAnnotations } from '../metadata.js'
 
 interface JobsItem {
   namespace: string

--- a/backend/src/controllers/trigger.ts
+++ b/backend/src/controllers/trigger.ts
@@ -3,7 +3,7 @@ import { CronJobController } from './cronjob.js'
 import assert from 'node:assert'
 import { randomBytes } from 'node:crypto'
 import { V1Job } from '@kubernetes/client-node'
-import { ForemanAnnotations } from '../annotations.js'
+import { ForemanAnnotations, ForemanLabels } from '../metadata.js'
 import { JobController } from './job.js'
 
 export class TriggerController {
@@ -40,10 +40,15 @@ export class TriggerController {
       annotations[ForemanAnnotations.DebugLogging] = 'true'
     }
 
+    // Ensure we can attribute the job to the cronjob later
+    const labels: Record<string, string> = {}
+    labels[ForemanLabels.CronJob] = cronJob.metadata.name
+
     const result = await this.k8s.triggerCronJob({
       cronJob,
       jobName: `${cronJob.metadata.name}-foreman-${randomId()}`,
       annotations,
+      labels,
       env
     })
 

--- a/backend/src/kubernetes/api.ts
+++ b/backend/src/kubernetes/api.ts
@@ -93,6 +93,7 @@ export class KubernetesApi {
     cronJob: V1CronJob
     jobName: string
     annotations?: Record<string, string>
+    labels?: Record<string, string>
     env: Record<string, string>
   }): Promise<V1Job> {
     assert.ok(options.cronJob.metadata?.namespace != null)
@@ -110,6 +111,7 @@ export class KubernetesApi {
     let jobBody = options.cronJob.spec.jobTemplate
     jobBody = applyMetadataName(jobBody, options.jobName)
     jobBody = applyMetadataAnnotations(jobBody, options.annotations ?? {})
+    jobBody = applyMetadataLabels(jobBody, options.labels ?? {})
     jobBody = applyEnvToJobContainers(jobBody, options.env)
     // Cleanup job after 1 hour
     jobBody = applyTtl(jobBody, 60 * 60)
@@ -128,6 +130,19 @@ function applyMetadataAnnotations (jobBody: k8s.V1Job, annotations: Record<strin
       annotations: {
         ...jobBody.metadata?.annotations,
         ...annotations
+      }
+    }
+  }
+}
+
+function applyMetadataLabels (jobBody: k8s.V1Job, labels: Record<string, string>): k8s.V1Job {
+  return {
+    ...jobBody,
+    metadata: {
+      ...jobBody.metadata,
+      labels: {
+        ...jobBody.metadata?.labels,
+        ...labels
       }
     }
   }

--- a/backend/src/metadata.ts
+++ b/backend/src/metadata.ts
@@ -4,3 +4,7 @@ export enum ForemanAnnotations {
   RepositoryScope = 'foreman.contane.net/repository-scope',
   DebugLogging = 'foreman.contane.net/debug-logging'
 }
+
+export enum ForemanLabels {
+  CronJob = 'foreman.contane.net/cronjob'
+}


### PR DESCRIPTION
In case the Renovate CronJob shares its namespace with other resources, we need to ensure that any jobs we return are actually related to the Renovate CronJob and not part of something else.

In the case of scheduled jobs, this is easily verified using the job's owner references. In the case of jobs triggered manually via Foreman, it appears we need to introduce a custom label by which we can then filter (which is what this patch does).

When testing this patch, non-related jobs no longer show up in Foreman while scheduled and manual jobs still do.