### PR TITLE
feat: Handle empty repository autodiscovery

### DIFF
--- a/frontend/src/pages/Job.tsx
+++ b/frontend/src/pages/Job.tsx
@@ -154,8 +154,11 @@ const Pod: FunctionComponent<{
 
   // A value between 0 and 1 representing the progress of repositories
   const progressValue = useMemo(() => {
-    if (progress == null || progress.length === 0) {
+    if (progress == null) {
       return 0
+    }
+    if (progress.length === 0) {
+      return 1
     }
     let value = 0
     for (const item of progress ?? []) {
@@ -208,6 +211,9 @@ const Pod: FunctionComponent<{
               />
             </div>
             <div className='mt-4'>
+              {progress.length === 0 && (
+                <p className='py-1'>No repositories were processed.</p>
+              )}
               {progress.map((item) => (
                 <ProgressItem key={item.repository} item={item} />
               ))}


### PR DESCRIPTION
When Renovate's autodiscovery turns up empty, for example when triggering a manual run with a non-existing repository scope, the log will not contain a list of matched repositories (not even an empty one). However, once the pod has completed, we know for a fact that no repositories are going to be discovered any more.
We can then show an empty list indicator, instead of continuing to show a loading indicator.

Screenshot:

![image](https://github.com/user-attachments/assets/62a0e3cd-ac1d-49a6-9b1b-6e3d159e0d98)
