### PR TITLE
chore: Remove initial heading from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-## Description
-
 <!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->
 
 Fixes #(issue)


### PR DESCRIPTION
## Description

GitHub places the commit message at the beginning of the PR body, i.e., above the "Description" heading. This requires manual effort to cut and paste it to the proper location. If we remove the heading, the message is already at the proper location.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
