### PR TITLE
feat: Handle termination signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE 8080
 
 # use tini as init process since Node.js isn't designed to be run as PID 1
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["node", "--disable-proto=delete", "dist/server.js"]
+CMD ["node", "--disable-proto=delete", "dist/main.js"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "npm run build --workspaces && node -e \"fs.rmSync('./dist',{force:true,recursive:true})\" && tsc",
     "lint": "npm run lint --workspaces && tsc --noEmit -p tsconfig.lint.json && eslint --ignore-path .gitignore src",
     "test": "npm run test --workspaces --if-present && mocha --require tsx --recursive \"test/**/*.ts\"",
-    "start": "node --disable-proto=delete dist/server.js"
+    "start": "node --disable-proto=delete dist/main.js"
   },
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,89 @@
+import path from 'node:path'
+import { Config, readConfigDirectory } from './config.js'
+import { StructError } from 'superstruct'
+import pino from 'pino'
+import { startServer } from './server.js'
+import { getPort } from './environment.js'
+import { KubeConfig } from '@kubernetes/client-node'
+import { loadKubeConfig } from './kube-config.js'
+
+const log = pino({
+  level: 'info',
+  // do not log pid and hostname
+  base: undefined,
+  // use ISO strings for timestamps instead of milliseconds
+  timestamp: pino.stdTimeFunctions.isoTime,
+  // use string levels (e.g., "info") instead of level numbers (e.g., 30)
+  formatters: {
+    level: (label) => ({ level: label }),
+    log: (object) => {
+      if (object instanceof Error) {
+        return pino.stdSerializers.errWithCause(object)
+      }
+      return object
+    }
+  }
+})
+
+log.info('process_start')
+
+let config: Config
+try {
+  config = await readConfigDirectory(path.join(process.cwd(), 'config'))
+} catch (error) {
+  if (error instanceof StructError) {
+    // the value may contain secrets, so don't log it
+    error.value = undefined
+    error.branch = []
+  }
+  log.fatal(error, 'config_error')
+  process.exit(1)
+}
+
+let port: number
+try {
+  port = getPort()
+} catch (error) {
+  log.fatal(error, 'config_error')
+  process.exit(1)
+}
+
+let kubeConfig: KubeConfig
+try {
+  kubeConfig = loadKubeConfig(log, config)
+} catch (error) {
+  log.fatal(error, 'config_error')
+  process.exit(1)
+}
+
+const abortController = new AbortController()
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.once(signal, () => {
+    log.info({ signal }, 'process_signal')
+    abortController.abort()
+  })
+}
+
+try {
+  const close = await startServer({
+    log,
+    config,
+    port,
+    kubeConfig
+  })
+
+  if (abortController.signal.aborted) {
+    await close()
+  } else {
+    abortController.signal.addEventListener('abort', () => {
+      close().then(() => {
+        log.info('server_closed')
+      }).catch((error) => {
+        log.error(error, 'server_close_error')
+      })
+    })
+  }
+} catch (error) {
+  log.fatal(error, 'uncaught_error')
+  process.exit(1)
+}


### PR DESCRIPTION
This patch adds handling of SIGINT and SIGTERM so that the server is closed gracefully. It also moves the code that starts the server into a function (in `server.ts`), separate from the command-line entrypoint (in newly-added `main.ts`). This way, each code part's responsibilities are clearer than if the process exit logic was conflated with running Fastify.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
