### PR TITLE
chore: Group updates to devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
     {
       "matchFileNames": ["Dockerfile"],
       "semanticCommitType": "fix"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": [
+        "^@types/",
+        "-types$"
+      ],
+      "groupName": "dev dependencies (non-major)",
+      "groupSlug": "dev-dependencies-non-major"
     }
   ]
 }


### PR DESCRIPTION
There are currently 5 open PRs by Renovate for updating dev dependency patch releases. To reduce review effort, group all of them together into a single PR (except semver-major updates).

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
