### PR TITLE
fix: Remove unnecessary `??` operator

### DIFF
--- a/backend/src/api/jobs.ts
+++ b/backend/src/api/jobs.ts
@@ -43,7 +43,7 @@ function project (job: V1Job): JobsItem {
   const isSuccess = typeof job.status?.succeeded === 'number' && job.status.succeeded > 0
   const isActive = typeof job.status?.active === 'number' && job.status.active > 0
 
-  const isManual = job.metadata?.annotations?.[ForemanAnnotations.Manual] === 'true' ?? false
+  const isManual = job.metadata?.annotations?.[ForemanAnnotations.Manual] === 'true'
   const repositoryScope = job.metadata?.annotations?.[ForemanAnnotations.RepositoryScope]
   const debugLogging = job.metadata?.annotations?.[ForemanAnnotations.DebugLogging] != null
     ? job.metadata.annotations[ForemanAnnotations.DebugLogging] === 'true'


### PR DESCRIPTION
When updating to TypeScript 5.6, it now (correctly) complains:

> src/api/jobs.ts(46,20): error TS2869: Right operand of ?? is
> unreachable because the left operand is never nullish.

Hence, the unreachable code is removed.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

## Additional Context

<!-- Add any other context or information about the pull request here. -->

TypeScript PR: #102

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
