### PR TITLE
chore: Include types in Renovate dev-deps group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,10 +16,6 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": [
-        "^@types/",
-        "-types$"
-      ],
       "groupName": "dev dependencies (non-major)",
       "groupSlug": "dev-dependencies-non-major"
     }


### PR DESCRIPTION
This is meant to further reduce the number of PRs and review effort. Historically, `@types` updates have been very safe to merge overall and should not conflict when grouped this way.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
