### PR TITLE
fix: Avoid crash if run without config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .fleet
+.vscode
 node_modules/
 .DS_Store
 npm-debug.log*

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,7 +104,18 @@ export const defaultConfig: Config = Object.freeze({
 })
 
 export async function readConfigDirectory (directory: string): Promise<Config> {
-  const entries = await fs.promises.readdir(directory, { withFileTypes: true })
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(directory, { withFileTypes: true })
+  } catch (err: unknown) {
+    if (typeof err === 'object' && err != null && 'code' in err && err.code === 'ENOENT') {
+      // ignore missing config directory
+      entries = []
+    } else {
+      throw err
+    }
+  }
+
   const configFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith('.yaml'))
 
   // sort by name, so that 01-foo.yaml is read before 02-bar.yaml

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,7 +1,14 @@
-import { createConfig } from '../src/config.js'
+import { createConfig, defaultConfig, readConfigDirectory } from '../src/config.js'
 import assert from 'node:assert'
 
 describe('config.ts', () => {
+  describe('readConfigDirectory()', () => {
+    it('returns the default config if the directory is missing', async () => {
+      const config = await readConfigDirectory('missing-dir')
+      assert.deepStrictEqual(config, defaultConfig)
+    })
+  })
+
   describe('createConfig()', () => {
     it('creates a valid config object', () => {
       assert.doesNotThrow(() => createConfig())


### PR DESCRIPTION
Foreman works when started with an empty config directory, but if it was missing entirely, the application would crash. This was never discovered because the Helm chart guarantees existence of the config directory.

A test is added to verify the fix.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [x] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
