### PR TITLE
chore: Group updates to dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,13 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "dev dependencies (non-major)",
       "groupSlug": "dev-dependencies-non-major"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dependencies (non-major)",
+      "groupSlug": "dependencies-non-major"
     }
   ]
 }


### PR DESCRIPTION
Continuation of #95, adding a separate group for non-dev dependencies. There are 6 PRs currently that would be matched by the rule, which would greatly reduce maintenance effort, especially since we don't have to wait for each separate PR to be rebased before it can be merged.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
