### PR TITLE
chore!: Require Node.js v22.12.0 or later

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,8 @@
         "typescript": "5.7.2"
       },
       "engines": {
-        "node": ">=20",
-        "npm": ">=9"
+        "node": ">=22.12.0",
+        "npm": ">=10"
       }
     },
     "backend": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/contane/foreman#readme",
   "engines": {
-    "node": ">=20",
-    "npm": ">=9"
+    "node": ">=22.12.0",
+    "npm": ">=10"
   },
   "devDependencies": {
     "@eslint/compat": "1.2.4",


### PR DESCRIPTION
We already build the Docker image with Node.js 22. It makes sense to run the CI tests with the same version, and restrict non-containerized installations to v22 as well.

This is especially important since v22.12 added `require()` of ESM modules, which may greatly impact an application's run-time behaviour.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
