### PR TITLE
feat!: Update openid-client to v6, require HTTPS for issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The following configuration must be set in the OIDC provider, assuming Foreman i
 - Redirect URL: `https://foreman.example.com/api/auth/oidc/callback`
 
 It is assumed that your OIDC provider restricts which users can log in to Foreman, as no additional role checks are
-performed by Foreman.
+performed by Foreman. Additionally, the issuer must use HTTPS.
 
 ### GitLab integration
 

--- a/backend/src/fastifyPassport.ts
+++ b/backend/src/fastifyPassport.ts
@@ -2,3 +2,5 @@ import passport from '@fastify/passport'
 
 // Something is wrong with esModuleInterop... this is a workaround
 export const fastifyPassport = passport.default
+
+export const Authenticator = passport.Authenticator

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -90,7 +90,7 @@ export const backend = (kubeConfig: KubeConfig, config: BackendConfig): FastifyP
     fastifyPassport.use(AuthStrategy.OIDC, await makeOidcStrategy({
       ...config.auth.oidc,
       redirectUri: new URL(`${app.prefix}/auth/oidc/callback`, config.auth.oidc.publicUrl).toString()
-    }))
+    }) as any)
   }
 
   await app.register(strategiesAuthRoute(enabledAuthStrategies), { prefix: '/auth/strategies' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "dotenv": "16.4.7",
         "fastify": "5.2.0",
         "ms": "2.1.3",
-        "openid-client": "5.7.1",
+        "openid-client": "6.1.7",
         "passport-local": "1.0.0",
         "pino": "9.6.0",
         "react-router-dom": "7.1.1",
@@ -1922,28 +1922,6 @@
         "tmp-promise": "^3.0.2",
         "tslib": "^2.5.0",
         "ws": "^8.18.0"
-      }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/jose": {
-      "version": "5.9.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/openid-client": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.1.7.tgz",
-      "integrity": "sha512-JfY/KvQgOutmG2P+oVNKInE7zIh+im1MQOaO7g5CtNnTWMociA563WweiEMKfR9ry9XG3K2HGvj9wEqhCQkPMg==",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^5.9.6",
-        "oauth4webapi": "^3.1.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@lukeed/ms": {
@@ -6793,9 +6771,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7069,18 +7047,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/luxon": {
@@ -7547,15 +7513,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
@@ -7668,15 +7625,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -7696,15 +7644,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.1.7.tgz",
+      "integrity": "sha512-JfY/KvQgOutmG2P+oVNKInE7zIh+im1MQOaO7g5CtNnTWMociA563WweiEMKfR9ry9XG3K2HGvj9wEqhCQkPMg==",
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
+        "jose": "^5.9.6",
+        "oauth4webapi": "^3.1.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -11054,12 +11000,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dotenv": "16.4.7",
     "fastify": "5.2.0",
     "ms": "2.1.3",
-    "openid-client": "5.7.1",
+    "openid-client": "6.1.7",
     "passport-local": "1.0.0",
     "pino": "9.6.0",
     "react-router-dom": "7.1.1",


### PR DESCRIPTION
BREAKING CHANGE: Foreman now requires the OIDC issuer to use HTTPS. Plain HTTP is no longer supported for OpenID Connect authentication.

<!-- Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context. List any dependencies that are required for this change. -->

Replaces #150

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and optionally includes the scope, for example: `feat: Add social login`
